### PR TITLE
Fix IE11/Edge listbox interference bug

### DIFF
--- a/jquery.selectability.js
+++ b/jquery.selectability.js
@@ -330,7 +330,7 @@ Selectability.prototype.toggleCombobox = function() {
 
 Selectability.prototype.closeCombobox = function() {
   this.active = null;
-  this.listbox.empty();
+  this.listbox.hide().empty();
   this.combobox.attr('aria-expanded', false);
 };
 
@@ -343,7 +343,7 @@ Selectability.prototype.populateListbox = function() {
   this.populateText();
 
   var children = walk.call(this, this.element.children()).children();
-  this.listbox.append(children);
+  this.listbox.show().append(children);
   return;
 
   function walk (elements) {


### PR DESCRIPTION
This PR fixes a weird edge case in IE/Edge where the listbox height gets stuck after it closes. This causes it to interfere with elements below it on the page. The closed listbox is no longer visible, but clicking in the rectangle where it had been unexpectedly re-opens it.

<img width="458" alt="screen shot 2016-05-18 at 12 55 08 pm" src="https://cloud.githubusercontent.com/assets/143393/15367592/cd8d6e76-1cf7-11e6-8a5b-73dbd519aba0.png">

A little experimenting revealed that this only occurs when `max-height` and `overflow` properties are specified on the listbox. 

``` css
[role=listbox] {
    max-height: 240px;
    overflow: auto;
}
```

So it’s not at all obvious, but use of these properties with the listbox element is probably common.
